### PR TITLE
Add FindAllCertificates method

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -96,6 +96,61 @@ func (c *Context) FindCertificate(id []byte, label []byte, serial *big.Int) (*x5
 	return cert, err
 }
 
+// FindAllCertificates retrieves all certificates or a nil slice if none can be found.
+func (c *Context) FindAllCertificates() ([]*x509.Certificate, error) {
+
+	if c.closed.Get() {
+		return nil, errClosed
+	}
+
+	var certs []*x509.Certificate
+	err := c.withSession(func(session *pkcs11Session) (err error) {
+
+		var template []*pkcs11.Attribute
+		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_CERTIFICATE))
+
+		if err = session.ctx.FindObjectsInit(session.handle, template); err != nil {
+			return err
+		}
+		defer func() {
+			finalErr := session.ctx.FindObjectsFinal(session.handle)
+			if err == nil {
+				err = finalErr
+			}
+		}()
+
+		handles, _, err := session.ctx.FindObjects(session.handle, maxHandlePerFind)
+		if err != nil {
+			return err
+		}
+		if len(handles) == 0 {
+			return nil
+		}
+
+		for _, handle := range handles {
+			attributes := []*pkcs11.Attribute{
+				pkcs11.NewAttribute(pkcs11.CKA_VALUE, 0),
+			}
+
+			if attributes, err = session.ctx.GetAttributeValue(session.handle, handle, attributes); err != nil {
+				return err
+			}
+
+			cert, err := x509.ParseCertificate(attributes[0].Value)
+			if err != nil {
+				return err
+			}
+			certs = append(certs, cert)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return certs, err
+}
+
 // ImportCertificate imports a certificate onto the token. The id parameter is used to
 // set CKA_ID and must be non-nil.
 func (c *Context) ImportCertificate(id []byte, certificate *x509.Certificate) error {

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -207,7 +207,7 @@ func removeAllCertificates(t *testing.T, c *Context) {
 			t.Fatalf("failed to init: %s\n", e)
 		}
 		objs, _, e := session.ctx.FindObjects(session.handle, maxHandlePerFind)
-		if e != nil || len(objs) == 0 {
+		if e != nil {
 			t.Fatalf("failed to find objects")
 		}
 		if e := session.ctx.FindObjectsFinal(session.handle); e != nil {

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -27,6 +27,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"github.com/miekg/pkcs11"
 	"math/big"
 	"testing"
 	"time"
@@ -57,7 +58,9 @@ func TestFindAllCertificates(t *testing.T) {
 
 	gotCerts, err := ctx.FindAllCertificates()
 	require.NoError(t, err)
-	require.True(t, len(gotCerts) > 5)
+	require.Len(t, gotCerts, 5)
+
+	removeAllCertificates(t, ctx)
 }
 
 func TestCertificate(t *testing.T) {
@@ -93,6 +96,8 @@ func TestCertificate(t *testing.T) {
 	require.NotNil(t, cert2)
 
 	assert.Equal(t, cert.Signature, cert2.Signature)
+
+	removeAllCertificates(t, ctx)
 }
 
 // Test that provided attributes override default values
@@ -129,6 +134,8 @@ func TestCertificateAttributes(t *testing.T) {
 	// Find with new serial
 	c, err = ctx.FindCertificate(nil, nil, ourSerial)
 	assert.NotNil(t, c)
+
+	removeAllCertificates(t, ctx)
 }
 
 func TestCertificateRequiredArgs(t *testing.T) {
@@ -153,6 +160,8 @@ func TestCertificateRequiredArgs(t *testing.T) {
 
 	err = ctx.ImportCertificateWithLabel(val, val, nil)
 	require.Error(t, err)
+
+	removeAllCertificates(t, ctx)
 }
 
 func generateRandomCert(t *testing.T) *x509.Certificate {
@@ -182,4 +191,34 @@ func generateRandomCert(t *testing.T) *x509.Certificate {
 	require.NoError(t, err)
 
 	return cert
+}
+
+func removeAllCertificates(t *testing.T, c *Context) {
+	if c.closed.Get() {
+		t.Error(errClosed)
+	}
+
+	err := c.withSession(func(session *pkcs11Session) (err error) {
+
+		var template []*pkcs11.Attribute
+		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_CERTIFICATE))
+
+		if e := session.ctx.FindObjectsInit(session.handle, template); e != nil {
+			t.Fatalf("failed to init: %s\n", e)
+		}
+		objs, _, e := session.ctx.FindObjects(session.handle, maxHandlePerFind)
+		if e != nil || len(objs) == 0 {
+			t.Fatalf("failed to find objects")
+		}
+		if e := session.ctx.FindObjectsFinal(session.handle); e != nil {
+			t.Fatalf("failed to finalize: %s\n", e)
+		}
+		for _, obj := range objs {
+			if e := session.ctx.DestroyObject(session.handle, obj); e != nil {
+				t.Fatalf("DestroyObject failed: %s\n", e)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
 }

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -35,6 +35,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFindAllCertificates(t *testing.T) {
+	skipTest(t, skipTestCert)
+
+	ctx, err := ConfigureFromFile("config")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, ctx.Close())
+	}()
+
+	for i := 0; i < 5; i++ {
+		id := randomBytes()
+		label := randomBytes()
+
+		cert := generateRandomCert(t)
+
+		err = ctx.ImportCertificateWithLabel(id, label, cert)
+		require.NoError(t, err)
+	}
+
+	gotCerts, err := ctx.FindAllCertificates()
+	require.NoError(t, err)
+	require.True(t, len(gotCerts) > 5)
+}
+
 func TestCertificate(t *testing.T) {
 	skipTest(t, skipTestCert)
 


### PR DESCRIPTION
This pull request add new method `FindAllCertificates` on `*crypto11.Context` class. The use case of this method is when the client doesn't know any details about certificates stored in HSM token but want to retrieve/lookup for the certificate.

**Changes:**

- Add `FindAllCertificates` method. The code is based on `FindCertificate` and was edited for the new functionality. The code duplication between `FindCertificate` and `FindAllCertificates` can be removed but I think it's fine to leave it like this for now.
- Add `TestFindAllCertificates` function in `certificates_test.go` to test `FindAllCertificates` method
- Add `removeAllCertificates` in `certificates_test.go` helper function that find and remove all certificates in the token
- Add `removeAllCertificates()` at the end of each test cases in `certificates_test.go` to make each case independent of each other