### PR TITLE
Add finding certificate chain

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -85,7 +85,7 @@ func TestErrorAfterClosed(t *testing.T) {
 	_, err = ctx.NewRandomReader()
 	assert.Equal(t, errClosed, err)
 
-	cert := generateRandomCert(t)
+	cert := generateRandomCert(t, nil, "Foo", nil, nil)
 
 	err = ctx.ImportCertificate(bytes, cert)
 	assert.Equal(t, errClosed, err)


### PR DESCRIPTION
This PR adds functionality to retrieve the certificate chain with `FindCertificateChain` function. This function has the same format as the existing `FindCertificate` function. The search of the first certificate is done by id, label, or serial, similar to `FindCertificate` function. The search of the rest certificates is done by issuer - subject path. If the corresponding certificate is not found by the subject, it tries to find it by authority - subject key id path.