### PR TITLE
add salt length calculation with PSSSaltLengthAuto

### DIFF
--- a/rsa.go
+++ b/rsa.go
@@ -251,11 +251,12 @@ func signPSS(session *pkcs11Session, key *pkcs11PrivateKeyRSA, digest []byte, op
 		return nil, err
 	}
 	switch opts.SaltLength {
-	case rsa.PSSSaltLengthAuto: // parseltongue constant
-		// TODO we could (in principle) work out the biggest
-		// possible size from the key, but until someone has
-		// the effort to do that...
-		return nil, errUnsupportedRSAOptions
+	case rsa.PSSSaltLengthAuto:
+		if k, ok := key.pkcs11PrivateKey.pubKey.(*rsa.PublicKey); ok {
+			sLen = uint(k.N.BitLen()-1+7)/8 - 2 - hLen
+		} else {
+			return nil, errUnsupportedRSAOptions
+		}
 	case rsa.PSSSaltLengthEqualsHash:
 		sLen = hLen
 	default:


### PR DESCRIPTION
### Description

This PR adds support for signing using rsa.PSSSaltLengthAuto

When PSSSaltLengthAuto is set, the maximum salt length must equal:

  (modulus_key_size - 1 + 7)/8 - hash_length - 2

For example, for a 4096-bit modules key and SHA256 it should be:

  (4096 - 1 + 7)/8 - 32 - 2 = 478

See https://golang.org/cl/302230