### PR TITLE
Fix to/from array conversions for windows

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -1,15 +1,26 @@
 package crypto11
 
 import (
+	"encoding/hex"
+	"fmt"
 	"testing"
 )
 
-func TestULongMasking(t *testing.T) {
+func TestUlongToBytes(t *testing.T) {
 	ulongData := uint(0x33221100ddccbbaa)
 	ulongSlice := ulongToBytes(ulongData)
 
+	expected := "AABBCCDD00112233"
+	actual := fmt.Sprintf("%X", string(ulongSlice))
+	if expected != actual {
+		t.Errorf("expected %s != %s", expected, actual)
+	}
+}
+
+func TestBytesToUlong(t *testing.T) {
 	// Build an slice that is longer than the size of a ulong
-	extraLongSlice := append(ulongSlice, ulongSlice...)
+	extraLongSlice, _ := hex.DecodeString("AABBCCDD00112233AABBCCDD00112233")
+	ulongSlice := extraLongSlice[0:8]
 
 	tests := []struct {
 		slice    []uint8
@@ -30,7 +41,7 @@ func TestULongMasking(t *testing.T) {
 	for _, test := range tests {
 		got := bytesToUlong(test.slice)
 		if test.expected != got {
-			t.Errorf("conversion failed: 0x%X != 0x%X", test.expected, got)
+			t.Errorf("conversion failed: expected 0x%X != 0x%X", test.expected, got)
 		}
 	}
 }


### PR DESCRIPTION
Thank you for  the wonderful library. I have only one issue that i want to address here. The library does not work under windows when trying to call any function that (de)serializes data to/from bytes. The issue was detected during testing with SoftHSM.

Affected functions:

* `common.ulongToBytes()`
* `common.bytesToUlong()`

Affected platform: **windows10** but i guess, any recent windows will have the same issue.

## General

`ulong` is **at least** 32 bit integer, according to [the standard](https://en.cppreference.com/w/c/language/arithmetic_types).

The go-`uint` has 64 bits, on windows **and** linux, but [C.sizeof_ulong](https://github.com/ThalesGroup/crypto11/pull/103/files#diff-f414a6ec09d90228aa7bafc117eaddd89d204ece70f1ee674027aa393ed63939L35) is **0x4** on windows (MSVC), and **0x8** on linux (GCC, Clang).

But even if the value is in HSM, the code can't read it properly, because `bytesToUlong` [checks](https://github.com/ThalesGroup/crypto11/pull/103/files#diff-f414a6ec09d90228aa7bafc117eaddd89d204ece70f1ee674027aa393ed63939L45)
`if sliceSize > C.sizeof_ulong`.

The key of the problem is that widely used `uint` can't be trivially mirrored to the C code because it's length is in C (generally) undefined.

## Fix

The  proposed change uses existing go standard libraries to achieve the same behavior without touching the implementation too much.

I also took a look at the [pkcs11 docu](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cs01/pkcs11-curr-v2.40-cs01.html) to make sure the endianness is correct.

As the code of crypto11 only uses little-endian to convert **data**, the change is safe. 

> [!NOTE]
> the both changed common-functions should not be applied to e.g. `CKA_OTP_COUNTER` that requires big-endian (see pkcs11 docu above).

## Similar issues

Got something similar like [FindAllKeyPairs breaks on unsupported key type](https://github.com/ThalesIgnite/crypto11/issues/68). BTW @Knacktus what do you think?

## Steps to reproduce

Initially i faced the issue on work when trying to read some values. Got something from `FindAllKeyPairs` which came initially from `bytesToUlong`. I temporarily fixed it on my local machine.

Then i prepared a setup at home:

* Install SoftHSM2 e.g. [from here](https://github.com/disig/SoftHSM2-for-Windows).
* Make sure that `SOFTHSM2_CONF` env variable is exported and points to some valid SoftHSM2 config file, e.g. `D:\WHATEVER_PATH_TO_SoftHSM2\etc\softhsm2.conf` - there is one that comes (i believe) with the SoftHSM2 installation.
* `softhsm2-util.exe --init-token --label crypto11_test --slot 0`, to initialize the slot, enter some test pin
* Adapt config file in the root of the repo, use pin entered above:

```conf
{
  "Path" : "D:\\WHATEVER_PATH_TO_SoftHSM2\\lib\\softhsm2-x64.dll",
  "TokenLabel": "crypto11_test",
  "Pin" : "YOUR_PIN_HERE"
}
```

Checkout db3e0802, run `go test` - both `TestUlongToBytes` and `TestBytesToUlong` fail.
Initially, i played around with the `TestULongMasking` but then decided to split it into 2 parts, each testing its own function.
Hope it is ok like that.

Checkout my last commit, repeat `go test` - ok.

## Possible improvements

I added docu-comment to the functions to point their actual little-endian nature.
If you want, i can template it somehow to make endianness more explicit / selectable.

I think it is also reasonable to rename these functions, at least `ulong -> uint`.

## References

[wiki about data models](https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models) - see table
[a research about standard data types](http://synfare.com/JO59hw/hwdocs/sizes.html) - see results table

Thank you for your attention and i hope you will find time to review the proposed change!