### PR TITLE
HMAC cleanup fixes

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -206,13 +206,13 @@ func (hi *hmacImplementation) Sum(b []byte) []byte {
 			// http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc322855304
 			// We must ensure that C_SignUpdate is called _at least once_.
 			if err = hi.session.ctx.SignUpdate(hi.session.handle, []byte{}); err != nil {
+				hi.cleanup()
 				panic(err)
 			}
 		}
 		hi.result, err = hi.session.ctx.SignFinal(hi.session.handle)
 		hi.cleanup()
 		if err != nil {
-			hi.cleanup()
 			panic(err)
 		}
 	}

--- a/hmac.go
+++ b/hmac.go
@@ -150,7 +150,14 @@ func (hi *hmacImplementation) initialize() (err error) {
 	}
 
 	hi.session = session
+	// Idempotent: a multi-part operation can fail at several points, each of which
+	// must release the session. Putting it back twice would hand the same session
+	// to two callers, so guard on the nil sentinel.
 	hi.cleanup = func() {
+		// Check if the session has already been cleared
+		if hi.session == nil {
+			return
+		}
 		hi.key.context.pool.Put(session)
 		hi.session = nil
 	}
@@ -170,7 +177,15 @@ func (hi *hmacImplementation) Write(p []byte) (n int, err error) {
 		}
 		return
 	}
+	if hi.session == nil {
+		// A previous step failed and released the session, meaning the operation is dead.
+		err = errHmacClosed
+		return
+	}
 	if err = hi.session.ctx.SignUpdate(hi.session.handle, p); err != nil {
+		// The operation is dead, so release the session here as Sum (which normally
+		// cleans up) will not complete.
+		hi.cleanup()
 		return
 	}
 	hi.updates++
@@ -180,6 +195,12 @@ func (hi *hmacImplementation) Write(p []byte) (n int, err error) {
 
 func (hi *hmacImplementation) Sum(b []byte) []byte {
 	if hi.result == nil {
+		if hi.session == nil {
+			// A previous step failed and released the session, so there is no result.
+			// Returning a (zero-length) value here would silently yield a bogus HMAC.
+			// Panic to match the existing finalize-failure behaviour instead.
+			panic(errHmacClosed)
+		}
 		var err error
 		if hi.updates == 0 {
 			// http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc322855304
@@ -191,6 +212,7 @@ func (hi *hmacImplementation) Sum(b []byte) []byte {
 		hi.result, err = hi.session.ctx.SignFinal(hi.session.handle)
 		hi.cleanup()
 		if err != nil {
+			hi.cleanup()
 			panic(err)
 		}
 	}

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -55,6 +55,23 @@ func TestHmac(t *testing.T) {
 
 }
 
+// After a multi-part HMAC fails mid-operation, cleanup() releases the session and
+// nils it out. These tests cover the resulting dead-operation guards without an HSM:
+// a zero-value hmacImplementation has both session and result nil, the same state.
+func TestHmacWriteAfterSessionReleased(t *testing.T) {
+	hi := &hmacImplementation{}
+	n, err := hi.Write([]byte("data"))
+	require.Equal(t, errHmacClosed, err)
+	require.Zero(t, n)
+}
+
+func TestHmacSumAfterSessionReleased(t *testing.T) {
+	hi := &hmacImplementation{}
+	require.PanicsWithValue(t, errHmacClosed, func() {
+		hi.Sum(nil)
+	})
+}
+
 func testHmac(t *testing.T, ctx *Context, keyLabel string, keytype int, mech int, length int, xlength int, full bool) {
 
 	skipIfMechUnsupported(t, ctx, uint(mech))

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -37,20 +37,17 @@ func TestHmac(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	info, err := ctx.ctx.GetInfo()
-	require.NoError(t, err)
-
-	if info.ManufacturerID == "SoftHSM" {
-		t.Skipf("HMAC not implemented on SoftHSM")
-	}
+	// The hash-independent subtests (Empty/MultiSum/Reset) run once, under the plain SHA256
+	// case, so they exercise a mechanism most (all?) HSMs support. The _GENERAL cases are
+	// skipped there (skipIfMechUnsupported) as SoftHSM has no _GENERAL variants.
 	t.Run("HMACSHA1", func(t *testing.T) {
 		testHmac(t, ctx, "hmac1", pkcs11.CKK_SHA_1_HMAC, pkcs11.CKM_SHA_1_HMAC, 0, 20, false)
 	})
 	t.Run("HMACSHA1General", func(t *testing.T) {
-		testHmac(t, ctx, "hmac1", pkcs11.CKK_SHA_1_HMAC, pkcs11.CKM_SHA_1_HMAC_GENERAL, 10, 10, true)
+		testHmac(t, ctx, "hmac1", pkcs11.CKK_SHA_1_HMAC, pkcs11.CKM_SHA_1_HMAC_GENERAL, 10, 10, false)
 	})
 	t.Run("HMACSHA256", func(t *testing.T) {
-		testHmac(t, ctx, "hmac0", pkcs11.CKK_SHA256_HMAC, pkcs11.CKM_SHA256_HMAC, 0, 32, false)
+		testHmac(t, ctx, "hmac0", pkcs11.CKK_SHA256_HMAC, pkcs11.CKM_SHA256_HMAC, 0, 32, true)
 	})
 
 }

--- a/symmetric.go
+++ b/symmetric.go
@@ -344,10 +344,16 @@ func (c *Context) GenerateSecretKeyWithAttributes(template AttributeSet, bits in
 				return err
 			}
 
-			// nShield returns CKR_TEMPLATE_INCONSISTENT if if doesn't like the CKK/CKM combination.
-			// AWS CloudHSM returns CKR_ATTRIBUTE_VALUE_INVALID in the same circumstances.
+			// A token that doesn't recognise this CKK/CKM pairing should fall through to the
+			// next GenParams entry if there is one (e.g. the generic-secret fallback). The rejection
+			// code varies by vendor for the vendor-specific HMAC key-gen mechs: nShield returns
+			// CKR_TEMPLATE_INCONSISTENT, AWS CloudHSM CKR_ATTRIBUTE_VALUE_INVALID, SoftHSM
+			// CKR_MECHANISM_INVALID, and Utimaco CKR_ATTRIBUTE_TYPE_INVALID.
 			if e, ok := err.(pkcs11.Error); ok &&
-				e == pkcs11.CKR_TEMPLATE_INCONSISTENT || e == pkcs11.CKR_ATTRIBUTE_VALUE_INVALID {
+				(e == pkcs11.CKR_TEMPLATE_INCONSISTENT ||
+				e == pkcs11.CKR_ATTRIBUTE_VALUE_INVALID ||
+				e == pkcs11.CKR_MECHANISM_INVALID ||
+				e == pkcs11.CKR_ATTRIBUTE_TYPE_INVALID) {
 				continue
 			}
 


### PR DESCRIPTION
#### Proposed Changes ####

While reviewing HMAC error paths, I started looking into the way that errors are returned from `Sum()`. This can only panic, due to the Go APIs. I was looking into how best to recover from that when I spotted a leak of the session handle. As HMAC is a multi-step process, errors can occur at points where the existing `cleanup` function isn't called—this change closes those gaps.

This change does introduce the possibility that `cleanup` will be called twice, which would cause the session to be returned to the pool twice. This is guarded against by adding a test for `hi.session == nil` at the start of `cleanup`.

When testing, I also spotted that the tests didn't run on SoftHSM, as there's a comment that SoftHSM doesn't support HMAC. I'm not sure if this relates to an older version of SoftHSM? Current versions do support HMAC (I'm using it in production), so I removed this guard.

That then exposed a bug in `symmetric.go` where the fallback from a specific key type to a generic key wasn't being allowed as the particular return type didn't match the code's expectations—it turns out that I've been working around this at the application layer without realising what the issue was. I've checked the return values given by SoftHSM and the Utimaco HSM simulator and have updated the check to work with both of those, as well as the previous nShield and CloudHSM values. (My workaround was to copy the `CipherHMACSHA384` definition into my code, but to remove the first entry in the `GenParams` list, leaving only the generic secret option.)

#### Types of Changes ####

Bugfix

#### Verification ####

New and updated test cases cover the majority of the functionality. For the 'mid process' error case, though, this is difficult to test and will probably have to be left as just reviewed.

#### Testing ####

I've updated the HMAC tests to cover cases where my changes may have changed behaviour (or could trigger problems). I've not been able to test the specific leak, as to do wo would need a way to inject faults into the HSM session and I'm not sure how/if that can be done.

I've also updated the general HMAC tests (as mentioned above) to allow testing from SoftHSM. As well as enabling the tests and fixing the bug on mechanism fallback, I've also moved the 'full' test flag from the truncated 'general' HMAC (which isn't supported on SoftHSM) onto the full SHA256 HMAC, which should be supported everywhere.

Tests have been run against SoftHSM and Utimaco HSM simulator—I may be able to test against CloudHSM in a few days.

#### Linked Issues ####

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
In very rare cases, the HSM session could leak during HMAC operations.

Exported HMAC key definitions (e.g. `CipherHMACSHA384`) will now work as expected on SoftHSM and Utimaco HSMs.
```

#### Further Comments ####

The precise trigger for the errors investigation was CloudHSM—an HSM in the cluster can be removed at any time, creating a need to retry any operations which were in progress at the time. Retrying signing was easy enough, but HMAC is more difficult due to the Go APIs and the lack of an error return (just the panic). This then led to digging further and spotting the potential for a leak.